### PR TITLE
Update CI name to be equal to tag

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -54,7 +54,7 @@ jobs:
           draft: false
           prerelease: false
           fail_on_unmatched_files: true
-          name: '${{ github.repository }}: ${{ github.ref_name }}'
+          name: v${{ steps.date.outputs.today }}.${{ github.run_number }}
           body: |
             ${{ steps.notes.outputs.notes }}
 


### PR DESCRIPTION
To let the name equal to the tag in the nightlies:

![image](https://user-images.githubusercontent.com/2673520/153819165-8f6fe81a-ebed-456b-97dc-5e80c13fbf00.png)
